### PR TITLE
feat: numbers html view

### DIFF
--- a/lib/suzy_web/components/core_components.ex
+++ b/lib/suzy_web/components/core_components.ex
@@ -196,9 +196,9 @@ defmodule SuzyWeb.CoreComponents do
   def simple_form(assigns) do
     ~H"""
     <.form :let={f} for={@for} as={@as} {@rest}>
-      <div class="mt-10 space-y-8 bg-white">
+      <div class="p-6 space-x-4 flex flex-row items-center">
         <%= render_slot(@inner_block, f) %>
-        <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">
+        <div :for={action <- @actions} class="ml-2 flex items-center justify-between gap-6">
           <%= render_slot(action, f) %>
         </div>
       </div>
@@ -361,7 +361,7 @@ defmodule SuzyWeb.CoreComponents do
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""
-    <div phx-feedback-for={@name}>
+    <div phx-feedback-for={@name} class="flex flex-rows items-center pg-6">
       <.label for={@id}><%= @label %></.label>
       <input
         type={@type}
@@ -369,7 +369,7 @@ defmodule SuzyWeb.CoreComponents do
         id={@id}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
-          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          "ml-2 block rounded-lg text-slate-900 focus:ring-0 sm:text-sm sm:leading-6",
           "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
           @errors != [] && "border-rose-400 focus:border-rose-400"

--- a/lib/suzy_web/components/layouts/app.html.heex
+++ b/lib/suzy_web/components/layouts/app.html.heex
@@ -24,8 +24,8 @@
     </div>
   </div>
 </header>
-<main class="px-4 py-20 sm:px-6 lg:px-8">
-  <div class="mx-auto max-w-2xl">
+<main class="px-4 py-4 sm:px-6 lg:px-8">
+  <div class="mx-auto">
     <.flash_group flash={@flash} />
     <%= @inner_content %>
   </div>

--- a/lib/suzy_web/controllers/number_html.ex
+++ b/lib/suzy_web/controllers/number_html.ex
@@ -1,0 +1,58 @@
+defmodule SuzyWeb.NumberHTML do
+  use SuzyWeb, :html
+
+  embed_templates "number_html/*"
+
+  attr :num, :integer, required: true
+
+  def number(assigns) do
+    ~H"""
+    <div class="p-4 rounded-lg shadow-lg bg-slate-100"><%= @num %></div>
+    """
+  end
+
+  attr :nums, :list, required: true
+
+  def numbers_grid(assigns) do
+    ~H"""
+    <section
+      id="numbers-grid"
+      class="grid grid-cols-10 gap-4 font-mono text-sm text-center font-bold rounded-lg"
+    >
+      <.number :for={num <- @nums} num={num} />
+    </section>
+    """
+  end
+
+  attr :pagination, :map, required: true
+
+  def navigation(assigns) do
+    ~H"""
+    <% {pg, pg_size} = {@pagination["page"], @pagination["page_size"]} %>
+    <section id="navigation">
+      <.simple_form :let={f} for={@pagination} phx-change="validate" phx-submit="save">
+        <div class="space-x-4 flex flex-row items-baseline">
+          <.link :if={pg > 1} href={~p"/numbers?page=#{pg - 1}&page_size=#{pg_size}"}>
+            <.icon name="hero-chevron-double-left-solid" /> Prev
+          </.link>
+          <span :if={pg == 1} class="text-slate-400">
+            <.icon name="hero-chevron-double-left-solid" /> Prev
+          </span>
+
+          <span class="sep">|</span>
+          <.link href={~p"/numbers?page=#{pg + 1}&page_size=#{pg_size}"}>
+            Next <.icon name="hero-chevron-double-right-solid" />
+          </.link>
+
+          <span class="sep">|</span>
+          <.input field={f[:page]} label="Page" value={pg} />
+          <.input field={f[:page_size]} label="Page Size" value={pg_size} />
+        </div>
+        <:actions>
+          <.button>apply</.button>
+        </:actions>
+      </.simple_form>
+    </section>
+    """
+  end
+end

--- a/lib/suzy_web/controllers/number_html/index.html.heex
+++ b/lib/suzy_web/controllers/number_html/index.html.heex
@@ -1,0 +1,2 @@
+<.navigation pagination={@pagination} />
+<.numbers_grid nums={@nums} />

--- a/lib/suzy_web/router.ex
+++ b/lib/suzy_web/router.ex
@@ -18,6 +18,7 @@ defmodule SuzyWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    get "/numbers", NumberController, :index
   end
 
   scope "/api", SuzyWeb do

--- a/test/suzy_web/controllers/number_controller_test.exs
+++ b/test/suzy_web/controllers/number_controller_test.exs
@@ -1,36 +1,60 @@
 defmodule SuzyWeb.NumberControllerTest do
+  use SuzyWeb.ConnCase, async: true
   alias Suzy.Numbers
-  use SuzyWeb.ConnCase
+  import SuzyWeb.NumberController, only: [default_page: 0, default_page_size: 0]
 
-  describe "GET /api/numbers" do
-    test "without params", %{conn: conn} do
+  setup do
+    %{
+      page: default_page() |> String.to_integer(),
+      page_size: default_page_size() |> String.to_integer()
+    }
+  end
+
+  describe "index/2" do
+    test "without params", %{conn: conn, page: page, page_size: page_size} do
       conn = get(conn, ~p"/api/numbers")
-
       assert %{"numbers" => numbers} = json_response(conn, 200)
-      assert length(numbers) > 0
+      assert length(numbers) == page_size
       assert hd(numbers) == %{"value" => 1}
+
+      conn = get(conn, ~p"/numbers")
+      assert html = html_response(conn, 200)
+      assert {:ok, html} = Floki.parse_document(html)
+      assert Floki.find(html, "#numbers-grid div") |> length() == page_size
+      assert Floki.find(html, "#navigation a[href*=\"page=#{page + 1}\"]") != []
     end
 
-    test "with paging params", %{conn: conn} do
-      {page, page_size} = {2, 10}
+    test "with paging params", %{conn: conn, page: page, page_size: page_size} do
       start = (page - 1) * page_size + 1
       conn = get(conn, ~p"/api/numbers?page=#{page}&page_size=#{page_size}")
-
       assert %{"numbers" => numbers} = json_response(conn, 200)
       assert length(numbers) == page_size
       assert %{"value" => ^start} = hd(numbers)
+
+      start_s = "#{start}"
+      conn = get(conn, ~p"/numbers?page=#{page}&page_size=#{page_size}")
+      assert html = html_response(conn, 200)
+      assert {:ok, html} = Floki.parse_document(html)
+      assert Floki.find(html, "#numbers-grid div") |> length() == page_size
+      assert [{_e, _attrs, [^start_s]}] = Floki.find(html, "#numbers-grid div:first-of-type")
     end
 
     test "when page param out of range", %{conn: conn} do
       {page, page_size} = {-1, 100}
       conn = get(conn, ~p"/api/numbers?page=#{page}&page_size=#{page_size}")
       assert %{"errors" => %{"detail" => _}} = json_response(conn, 400)
+
+      conn = get(conn, ~p"/numbers?page=#{page}&page_size=#{page_size}")
+      assert html_response(conn, 400) =~ "Bad Request"
     end
 
     test "when page size param out of range", %{conn: conn} do
       {page, page_size} = {1, Numbers.max_number() + 1}
       conn = get(conn, ~p"/api/numbers?page=#{page}&page_size=#{page_size}")
       assert %{"errors" => %{"detail" => _}} = json_response(conn, 400)
+
+      conn = get(conn, ~p"/numbers?page=#{page}&page_size=#{page_size}")
+      assert html_response(conn, 400) =~ "Bad Request"
     end
   end
 end

--- a/test/suzy_web/controllers/number_html_test.exs
+++ b/test/suzy_web/controllers/number_html_test.exs
@@ -1,0 +1,49 @@
+defmodule SuzyWeb.NumberHtmlTest do
+  use SuzyWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+  alias SuzyWeb.NumberHTML
+
+  test "number/1" do
+    num = 1002
+    assert render_component(&NumberHTML.number/1, num: num) =~ ">1002</div>"
+  end
+
+  test "numbers_grid/1" do
+    nums = [6, 7, 8]
+    html = render_component(&NumberHTML.numbers_grid/1, nums: nums)
+
+    assert {:ok, html} = Floki.parse_document(html)
+    assert Floki.find(html, "#numbers-grid div") |> length() == 3
+    for num <- nums, do: assert(Floki.find(html, "#numbers-grid div:fl-contains('#{num}')") != [])
+  end
+
+  describe "navigation/1" do
+    test "render with pagination params" do
+      {page, page_size} = {3, 13}
+      pagination = %{"page" => page, "page_size" => page_size}
+      html = render_component(&NumberHTML.navigation/1, pagination: pagination)
+
+      assert {:ok, html} = Floki.parse_document(html)
+      assert Floki.find(html, "form") != []
+
+      # prev / next page links
+      assert Floki.find(html, "a[href*=\"page=#{page - 1}\"]") != []
+      assert Floki.find(html, "a[href*=\"page=#{page + 1}\"]") != []
+      assert Floki.find(html, "a[href*=\"page_size=#{page_size}\"]") |> length() == 2
+
+      # page / page size form inputs
+      assert Floki.find(html, "input#page[value=\"#{page}\"}]") != []
+      assert Floki.find(html, "input#page_size[value=\"#{page_size}\"}]") != []
+    end
+
+    test "when current page is 1" do
+      {page, page_size} = {1, 10}
+      pagination = %{"page" => page, "page_size" => page_size}
+      html = render_component(&NumberHTML.navigation/1, pagination: pagination)
+
+      assert {:ok, html} = Floki.parse_document(html)
+      refute Floki.find(html, "a[href*=\"page=#{page - 1}\"]") != []
+      assert Floki.find(html, "span:fl-contains('Prev')") |> length() == 1
+    end
+  end
+end


### PR DESCRIPTION
This PR enables numbers to be presented in an HTML view that features simple navigation and pagination. The view is underpinned by new Phoenix function components (e.g. `numbers-grid`) and the core components included in Phoenix, both with Tailwinds CSS styling and layouts. 

Limitation: the view is a first-slice, currently HTTP-based not streamed or "live" (LiveView). As such, numbers per page are generated in memory before being rendered, i.e. the view is memory-bound especially for very large page sizing.

<img width="911" alt="Screenshot 2023-10-12 at 14 54 57" src="https://github.com/boonious/suzy/assets/104361/df24880e-47f8-4276-bf27-07329ecd6576">
